### PR TITLE
Set portfolio thumbnail upload folder to 'Portfolio'

### DIFF
--- a/src/Pages/CasePage.php
+++ b/src/Pages/CasePage.php
@@ -81,7 +81,8 @@ class CasePage extends \Page
                 _t('WeDevelop\Portfolio\Models\Customer.SINGULARNAME', 'Customer'),
                 Customer::get()->map()->toArray()
             )->setHasEmptyDefault(true),
-            UploadField::create('Thumbnail', _t(__CLASS__ . '.THUMBNAIL', 'Thumbnail')),
+            UploadField::create('Thumbnail', _t(__CLASS__ . '.THUMBNAIL', 'Thumbnail'))
+                ->setFolderName('Portfolio'),
         ]);
 
         return $fields;


### PR DESCRIPTION
As requested in our internal slack, the portfolio thumbnail now gets uploaded in the "Portfolio" folder (instead of "uploads")