### PR TITLE
feature/customer-flag: Added a flag to be able to disable using the customer model

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ You can also link customers/categories to cases and create a collection with dif
 ## Installation
 * `composer require wedevelopnl/silverstripe-portfolio`
 
+## Feature Flags
+
+### Customers
+Managing and linking customers can be disabled using the following config in your project
+
+```
+---
+Name: flags
+After: portfolio
+---
+WeDevelop\Portfolio\Config:
+  customer_enabled: false
+```
+
 ## License
 See [License](LICENSE)
 

--- a/_config/config.yml
+++ b/_config/config.yml
@@ -4,3 +4,6 @@ Name: portfolio
 WeDevelop\Portfolio\Pages\PortfolioPage:
   extensions:
     - SilverStripe\Lumberjack\Model\LumberJack
+
+WeDevelop\Portfolio\Config:
+  customer_enabled: true

--- a/src/Admins/PortfolioAdmin.php
+++ b/src/Admins/PortfolioAdmin.php
@@ -5,6 +5,7 @@ namespace WeDevelop\Portfolio\Admins;
 use SilverStripe\Admin\ModelAdmin;
 use WeDevelop\Portfolio\Models\Collection;
 use WeDevelop\Portfolio\Models\Customer;
+use WeDevelop\Portfolio\Config;
 
 class PortfolioAdmin extends ModelAdmin
 {
@@ -22,4 +23,15 @@ class PortfolioAdmin extends ModelAdmin
         Customer::class,
         Collection::class,
     ];
+
+    public function getManagedModels()
+    {
+        $models = parent::getManagedModels();
+
+        if (!Config::isCustomerEnabled()) {
+            unset($models[Customer::class]);
+        }
+
+        return $models;
+    }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -3,13 +3,21 @@
 namespace WeDevelop\Portfolio;
 
 use SilverStripe\Core\Config\Configurable;
+use SilverStripe\View\TemplateGlobalProvider;
 
-class Config
+class Config implements TemplateGlobalProvider
 {
     use Configurable;
 
-    public static function isCustomerEnabled()
+    public static function isCustomerEnabled(): bool
     {
         return self::config()->get('customer_enabled');
+    }
+
+    public static function get_template_global_variables(): array
+    {
+        return [
+            'WeDevelopPortfolioConfigIsCustomerEnabled' => 'isCustomerEnabled'
+        ];
     }
 }

--- a/src/Config.php
+++ b/src/Config.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace WeDevelop\Portfolio;
+
+use SilverStripe\Core\Config\Configurable;
+
+class Config
+{
+    use Configurable;
+
+    public static function isCustomerEnabled()
+    {
+        return self::config()->get('customer_enabled');
+    }
+}

--- a/src/Pages/CasePage.php
+++ b/src/Pages/CasePage.php
@@ -14,6 +14,7 @@ use WeDevelop\Portfolio\ElementalGrid\ElementPortfolio;
 use WeDevelop\Portfolio\Models\Category;
 use WeDevelop\Portfolio\Models\Collection;
 use WeDevelop\Portfolio\Models\Customer;
+use WeDevelop\Portfolio\Config;
 
 /**
  * @property DBDatetime $PublicationDate
@@ -96,6 +97,10 @@ class CasePage extends \Page
                 )->setHasEmptyDefault(true),
                 UploadField::create('Thumbnail', _t(__CLASS__ . '.THUMBNAIL', 'Thumbnail')),
             ]);
+
+            if (!Config::isCustomerEnabled()) {
+                $fields->removeByName('CustomerID');
+            }
         });
 
         return parent::getCMSFields();

--- a/templates/WeDevelop/Portfolio/Pages/Layout/CasePage.ss
+++ b/templates/WeDevelop/Portfolio/Pages/Layout/CasePage.ss
@@ -8,7 +8,7 @@
                 <li>$PublicationDate.Nice</li>
             <% end_if %>
         </ul>
-        <% if $Customer %>
+        <% if $Customer && $WeDevelopPortfolioConfigIsCustomerEnabled %>
             <span>$Customer.Title</span><br/>
         <% end_if %>
         <hr />


### PR DESCRIPTION
- Adds WeDevelop\Portfolio\Config as a generic config class
- Updates README with feature flag
- Flag disables the managed model in the Portfolio Admin
- Flag disables the Customer linking field
- Flag is enabled by default to prevent any issues when updating a minor version