### PR TITLE
Work around bug in the tagfield module.

### DIFF
--- a/src/Pages/CasePage.php
+++ b/src/Pages/CasePage.php
@@ -94,7 +94,10 @@ class CasePage extends \Page
                     _t('WeDevelop\Portfolio\Models\Category.PLURALNAME', 'Categories'),
                     Category::get()->filter('PortfolioPageID', $this->ParentID),
                     $this->Categories(),
-                )->setCanCreate(false),
+                ),
+                // Disabled `setCanCreate` because of a bug in the tagfield module.
+                // @see https://github.com/silverstripe/silverstripe-tagfield/issues/267
+                //->setCanCreate(false),
                 DropdownField::create(
                     'CustomerID',
                     _t('WeDevelop\Portfolio\Models\Customer.SINGULARNAME', 'Customer'),


### PR DESCRIPTION
Disable the `setCanCreate(false)` call in the category tag field, this breaks in the latest version of the module.

See: https://github.com/silverstripe/silverstripe-tagfield/issues/267